### PR TITLE
ci: update unit test job to run on only PR to main branch

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,10 +1,8 @@
-# Run the unit tests on push/PR merge to main branch
+# Run the unit tests on Pull Request to main branch
 
 name: Run unit tests
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
       branches: [ main ]
 


### PR DESCRIPTION
Update unit test job to run on only PR to `main` branch. This removes push action to `main` branch